### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,39 +3,6 @@ This repository contains the manual for the LabBench Software for conducting exp
 
 The manual is hosted on Github pages from the /docs directory [LINK](https://inventors-way.github.io/LabBench.Manual/)
 
+The manual is written in Github flavored Markdowwn, where you can use the  [editor on GitHub](https://github.com/Inventors-Way/LabBench.Manual/edit/master/README.md) to write the manual, or you can fork and clone the repository in for example Github Desktop and use an editor of your choice to edit the manual.
 
-You can use the [editor on GitHub](https://github.com/Inventors-Way/LabBench.Manual/edit/master/README.md) to maintain and preview the content for your website in Markdown files.
-
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
-
-### Markdown
-
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
-
-```markdown
-Syntax highlighted code block
-
-# Header 1
-## Header 2
-### Header 3
-
-- Bulleted
-- List
-
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
-```
-
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
-
-### Jekyll Themes
-
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/Inventors-Way/LabBench.Manual/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
-
-### Support or Contact
-
-Having trouble with Pages? Check out our [documentation](https://help.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+For a description of Github flavored Markdown, please refer to [Github Flavored Markdown](https://github.github.com/gfm/)


### PR DESCRIPTION
Simplified the README file, by making a link to GitHub Flavored Markdown instead of using the standard text that is automatically created when you install a theme on GitHub Pages.